### PR TITLE
feat: add preview-block for better placing preview.css

### DIFF
--- a/Application/views/blocks/base_style_overload.tpl
+++ b/Application/views/blocks/base_style_overload.tpl
@@ -1,0 +1,5 @@
+[{if $oxcmp_user && $oxcmp_user->oxuser__oxrights->value == "malladmin" && $smarty.cookies.scsspreview}]
+    [{oxstyle include="css/preview.css?"|cat:$smarty.now}]
+[{else}]
+    [{$smarty.block.parent}]
+[{/if}]

--- a/metadata.php
+++ b/metadata.php
@@ -25,6 +25,12 @@ $aModule = [
         'tests.tpl' => 'moga/Application/views/admin/tests.tpl',
         'report.tpl' => 'moga/Application/views/emails/report.tpl'
     ],
+    'blocks' => [
+    [
+        'template' => 'base.tpl',
+        'block'    => 'base_style_overload',
+        'file'     => 'Application/views/blocks/base_style_overload.tpl'
+    ]
     'settings' => [
         ['group' => 'mogaSettings', 'name' => 'blSendReportOnSave', 'type' => 'bool', 'value' => false],
 


### PR DESCRIPTION
@vanilla-thunder : Hello Marat i´ve a pull-request in the moga-theme to add an maintenance-task 

During review the theme-repo, I saw that you include a preview.css in the Moga theme. The construct is only needed if the moga module is used. That's why I added a block to the theme that can be overwritten by your module.
The new "base_style_overload" block is deliberately placed in the "base_style" block so that other modules can continue to use the "base_style" block. In the theme block "base_style_overload" only the [{oxstyle include = "css / styles.min.css"}] is stored so that your preview.css can overwrite it. 